### PR TITLE
Fix kubectl install command continuation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ ARG YQ_VERSION=4.44.3
 RUN set -euo pipefail; \
   curl -fL --retry 5 --retry-delay 2 \
     -o /usr/local/bin/kubectl \
-    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && 
-  chmod +x /usr/local/bin/kubectl && kubectl version --client
+    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+  chmod +x /usr/local/bin/kubectl && \
+  kubectl version --client
 
 # helm
 RUN set -euo pipefail; \


### PR DESCRIPTION
## Summary
- fix Dockerfile kubectl install step by adding line continuations to avoid parse error

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -t test-image .` *(fails: Cannot connect to the Docker daemon)*
- `dockerd` *(fails: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3b87404833394ebffdef23b23a0